### PR TITLE
firefox: Fix options link in the popup

### DIFF
--- a/src/js/services/html-generator.ts
+++ b/src/js/services/html-generator.ts
@@ -1,5 +1,5 @@
 import { CounterConfig, PullRequest, PullRequestRecord, PullRequestRecordKey } from '../static/types';
-import { recordKeysTranslations, extensionID } from '../static/constants';
+import { recordKeysTranslations } from '../static/constants';
 
 const HTMLGenerator = () => {
   const generate = (record: PullRequestRecord, counter: CounterConfig): HTMLDivElement => {

--- a/src/js/services/html-generator.ts
+++ b/src/js/services/html-generator.ts
@@ -55,7 +55,7 @@ const HTMLGenerator = () => {
     const p1 = document.createElement('p');
     const p2 = document.createElement('p');
     p1.textContent = 'Seems like you are a good coworker :)';
-    const link = `<a href="chrome-extension://${extensionID}/options.html" target="_blank" class="link-in-text">options&nbsp;</a>`;
+    const link = '<a href="options.html" target="_blank" class="link-in-text">options&nbsp;</a>';
     p2.innerHTML = `Or you configured the extension wrong. Have a look the ${link}  to verify your configuration.`;
     noContentDiv.appendChild(p1);
     noContentDiv.appendChild(p2);


### PR DESCRIPTION
The options page can just be relative to the popup page, which is also
in the `extension://.../` space.