### PR TITLE
Replace deprecated options_page with options_ui

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -7,7 +7,10 @@
   "action": {
     "default_popup": "popup.html"
   },
-  "options_page": "options.html",
+  "options_ui": {
+    "page": "options.html",
+    "open_in_tab": true
+  },
   "permissions": [
     "alarms",
     "storage"


### PR DESCRIPTION
options_page is deprecated and not supported in Firefox anymore. See https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/options_page

The new options_ui is supported in all browsers: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/options_ui