### PR TITLE
Revert "Invert sort order of PRs"

### DIFF
--- a/src/js/services/github-api-wrapper.test.ts
+++ b/src/js/services/github-api-wrapper.test.ts
@@ -441,12 +441,12 @@ describe('GithubApiWrapper', () => {
       beforeEach(() => MockDate.set('2021-07-08'));
       afterEach(() => MockDate.reset());
 
-      it('has the correct order (oldest first)', async () => {
+      it('has the correct order', async () => {
         const result = await (await GithubApiWrapper()).getAllAssigned();
 
-        expect(result[0].createdAt).toEqual('2021-04-15T14:17:00Z');
+        expect(result[0].createdAt).toEqual('2021-06-25T14:17:00Z');
         expect(result[1].createdAt).toEqual('2021-05-20T14:17:00Z');
-        expect(result[2].createdAt).toEqual('2021-06-25T14:17:00Z');
+        expect(result[2].createdAt).toEqual('2021-04-15T14:17:00Z');
       });
 
       describe('with a maximum age of 10 days', () => {

--- a/src/js/services/github-api-wrapper.test.ts
+++ b/src/js/services/github-api-wrapper.test.ts
@@ -441,7 +441,7 @@ describe('GithubApiWrapper', () => {
       beforeEach(() => MockDate.set('2021-07-08'));
       afterEach(() => MockDate.reset());
 
-      it('has the correct order', async () => {
+      it('has the correct order (newest first)', async () => {
         const result = await (await GithubApiWrapper()).getAllAssigned();
 
         expect(result[0].createdAt).toEqual('2021-06-25T14:17:00Z');

--- a/src/js/services/github-api-wrapper.ts
+++ b/src/js/services/github-api-wrapper.ts
@@ -114,7 +114,7 @@ const GithubApiWrapper = async () => {
 
   const sortByDate = (pullRequests: PullRequest[]) =>
     pullRequests.sort((pullRequest1: PullRequest, pullRequest2: PullRequest) => (
-      new Date(pullRequest1.createdAt).getTime() - new Date(pullRequest2.createdAt).getTime()
+      new Date(pullRequest2.createdAt).getTime() - new Date(pullRequest1.createdAt).getTime()
     ));
 
   const readOwnerAndNameFromUrl = (url: string): string => url.replace('https://api.github.com/repos/', '').split('/pulls/')[0];

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,7 +3,7 @@
   "author": "Renuo AG",
   "name": "Github Pull Request Counter",
   "description": "A chrome extension to remove mental load when working with pull requests.",
-  "version": "1.0.7",
+  "version": "1.0.9",
   "action": {
     "default_popup": "popup.html"
   },

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,7 +3,7 @@
   "author": "Renuo AG",
   "name": "Github Pull Request Counter",
   "description": "A chrome extension to remove mental load when working with pull requests.",
-  "version": "1.0.8",
+  "version": "1.0.7",
   "action": {
     "default_popup": "popup.html"
   },


### PR DESCRIPTION
I think this change was a bad idea. It feels unintuitive. I'd rather have the old behaviour back.