### PR TITLE
Unset width property on the body element

### DIFF
--- a/src/css/shared.css
+++ b/src/css/shared.css
@@ -2,6 +2,7 @@ body {
   background-color: var(--background-color);
   color: var(--font-color);
   margin: 10px;
+  width: unset;
 }
 
 a {


### PR DESCRIPTION
It is set by the css library and causes horizontal scrollbars on Firefox.